### PR TITLE
If you are reading this please consider

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,12 @@ messages.
 ### Dependencies
 - Start MSSQL Server 2017 docker container:
 	````
-	docker run -d --hostname mssqldb --name mssqldb_dev -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=P455w0rd123456789" -p 1433:1433 mcr.microsoft.com/mssql/server:2017-CU21-ubuntu-16.04`
+	docker run -d --hostname mssqldb --name mssqldb_dev -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=P455w0rd123456789" -p 1433:1433 mcr.microsoft.com/mssql/server:2017-CU21-ubuntu-16.04
 	````
 
 - Start RabbitMQ docker container:
 	````
-	docker run -d --hostname rabbitmq --name rabbitmq_dev -p 5672:5672 -p 15672:15672 rabbitmq:3-management`
+	docker run -d --hostname rabbitmq --name rabbitmq_dev -p 5672:5672 -p 15672:15672 rabbitmq:3-management
 	````
 
 ### Front-End - WebApp


### PR DESCRIPTION
After reviewing the README for the 1,000th time I noticed that when changing the styling of the install command for the dependencies, I forgot to remove a " **`** " at the end of them. Meaning that if you copy and paste the whole command and did not notice that, it will fail resulting in a bad developer experience. 

This PR fixes that issue.